### PR TITLE
Make sure Import-CliXML can find update_info.xml

### DIFF
--- a/au/update_all.ps1
+++ b/au/update_all.ps1
@@ -52,7 +52,7 @@ if ($env:au_force -eq 'true') {
 cd $PSScriptRoot/../automatic
 
 Update-AUPackages -Name $Name -Options $options | ft
-$global:updateall = Import-CliXML $PSScriptRoot\..\update_info.xml
+$global:updateall = Import-CliXML $PSScriptRoot\..\automatic\update_info.xml
 
 #Uncomment to fail the build on AppVeyor on any package error
 #if ($updateall.error_count.total) { throw 'Errors during update' }


### PR DESCRIPTION
Without this fix, I get

```
Import-CliXML : Die Datei "D:\Projects\chocolatey-packages\update_info.xml" konnte nicht gefunden werden.
In D:\Projects\chocolatey-packages\au\update_all.ps1:55 Zeichen:21
+ $global:updateall = Import-CliXML $PSScriptRoot\..\update_info.xml
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OpenError: (:) [Import-Clixml], FileNotFoundException
    + FullyQualifiedErrorId : FileOpenFailure,Microsoft.PowerShell.Commands.ImportClixmlCommand
```

See also https://ci.appveyor.com/project/Jonas/chocolatey-packages/build/17