### PR TITLE
(#54) Improves Parameters in Test and Update Scripts

### DIFF
--- a/test_all.ps1
+++ b/test_all.ps1
@@ -1,19 +1,60 @@
-#Name can be 'random N' to randomly force the Nth group of packages.
+<#
+    .Synopsis
+        Force updates all automatic packages in the repository.
 
-param( [string[]] $Name, [string] $Root = "$PSScriptRoot", [switch] $ThrowOnErrors = $false )
+    .Description
+        Uses Chocolatey AU to update packages in the specified folder (defaults to $PSScriptRoot\automatic),
+        outputting an error if any are found. Does not push any of the package updates.
+
+    .Example
+        .\test_all.ps1
+        # Force updates all packages in the default folder, \automatic.
+
+    .Example
+        .\test_all.ps1 -Name exampleid
+        # Attempts to force-update the 'exampleid' package, if present.
+
+    .Example
+        .\test_all.ps1 -Name 'random 5'
+        # Attempts to force-update 5 random packages that are present in the root folder.
+
+    .Notes
+        This will leave your repository in an un-clean state.
+#>
+[CmdletBinding()]
+param(
+    # Specific packages to test
+    # If set to 'random N' (where N is an int), randomly forces the Nth group of packages.
+    [ArgumentCompleter({
+        param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+        $Directory = if ($FakeBoundParameters['Root']) {
+            $FakeBoundParameters['Root']
+        } else {
+            "$PSScriptRoot\automatic"
+        }
+        (Get-ChildItem $Directory -Directory).Name.Where{
+            $_ -like "*$WordToComplete*" -and
+            $_ -notin $FakeBoundParameters['Name']
+        }
+    })]
+    [string[]]$Name,
+
+    # The directory to find packages in
+    [string]$Root = "$PSScriptRoot\automatic"
+)
 
 if (Test-Path $PSScriptRoot/update_vars.ps1) { . $PSScriptRoot/update_vars.ps1 }
 $global:au_root = Resolve-Path $Root
 
-if (($Name.Length -gt 0) -and ($Name[0] -match '^random (.+)')) {
-    [array] $lsau = lsau
+if ($Name.Count -eq 1 -and $Name[0] -match '^random (\d+)$') {
+    [array]$FoundPackages = Get-AUPackages
 
     $group = [int]$Matches[1]
     $n = (Get-Random -Maximum $group)
     Write-Host "TESTING GROUP $($n+1) of $group"
 
-    $group_size = [int]($lsau.Count / $group) + 1
-    $Name = $lsau | select -First $group_size -Skip ($group_size*$n) | % { $_.Name }
+    $group_size = [int]($FoundPackages.Count / $group) + 1
+    $Name = $FoundPackages | Select-Object -First $group_size -Skip ($group_size*$n) | Select-Object -ExpandProperty Name
 
     Write-Host ($Name -join ' ')
     Write-Host ('-'*80)
@@ -22,7 +63,7 @@ if (($Name.Length -gt 0) -and ($Name[0] -match '^random (.+)')) {
 $options = [ordered]@{
     Force   = $true
     Push    = $false
-    Threads = 10 
+    Threads = 10
 
     IgnoreOn = @(                                      #Error message parts to set the package ignore status
         'Could not create SSL/TLS secure channel'
@@ -66,11 +107,8 @@ $options = [ordered]@{
     }
 }
 
-
 $global:info = updateall -Name $Name -Options $Options
 
-$au_errors = $global:info | ? { $_.Error } | select -ExpandProperty Error
-
-if ($ThrowOnErrors -and $au_errors.Count -gt 0) {
-    throw 'Errors during update'
+if ($global:info.Where{$_.Error}) {
+    Write-Error 'Errors during update. Access $global:info for more information.'
 }

--- a/update_all.ps1
+++ b/update_all.ps1
@@ -1,4 +1,60 @@
-param([string[]] $Name, [string] $ForcedPackages, [string] $Root = "$PSScriptRoot\automatic")
+<#
+    .Synopsis
+        Updates all automatic packages in the repository.
+
+    .Description
+        Uses Chocolatey AU to update packages in the specified folder (defaults to $PSScriptRoot\automatic)
+        It then pushes and reports on updated packages, based on the present configuration.
+
+    .Example
+        .\update_all.ps1
+        # Attempts to update all packages in the default folder, \automatic.
+
+    .Example
+        .\update_all.ps1 -Name exampleid
+        # Attempts to update the 'exampleid' package, if present.
+
+    .Example
+        .\update_all.ps1 -ForcedPackage exampleid
+        # Attempts to update all packages and forces an update of 'exampleid'.
+#>
+[CmdletBinding()]
+param(
+    # Specific packages to update
+    [ArgumentCompleter({
+        param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+        $Directory = if ($FakeBoundParameters['Root']) {
+            $FakeBoundParameters['Root']
+        } else {
+            "$PSScriptRoot\automatic"
+        }
+        (Get-ChildItem $Directory -Directory).Name.Where{
+            $_ -like "*$WordToComplete*" -and
+            $_ -notin $FakeBoundParameters['Name']
+        }
+    })]
+    [string[]]$Name,
+
+    # Packages to update regardless of the current version
+    [ArgumentCompleter({
+        param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+        $Directory = if ($FakeBoundParameters['Root']) {
+            $FakeBoundParameters['Root']
+        } else {
+            "$PSScriptRoot\automatic"
+        }
+
+        (Get-ChildItem $Directory -Directory).Name.Where{
+            $_ -like "*$WordToComplete*"
+        } | Group-Object {
+            $_ -in $FakeBoundParameters['Name']
+        } | Sort-Object | Select-Object -ExpandProperty Group
+    })]
+    [string]$ForcedPackages,
+
+    # The directory to update packages in
+    [string]$Root = "$PSScriptRoot\automatic"
+)
 
 if (Test-Path $PSScriptRoot/update_vars.ps1) { . $PSScriptRoot/update_vars.ps1 }
 
@@ -37,7 +93,7 @@ $Options = [ordered]@{
     )
     #RepeatSleep   = 250                                    #How much to sleep between repeats in seconds, by default 0
     #RepeatCount   = 2                                      #How many times to repeat on errors, by default 1
-    
+
     #NoCheckChocoVersion = $true                            #Turn on this switch for all packages
 
 
@@ -116,4 +172,4 @@ $global:au_GalleryUrl   = ''             #URL to package gallery, leave empty fo
 $global:info = updateall -Name $Name -Options $Options
 
 #Uncomment to fail the build on AppVeyor on any package error
-#if ($global:info.error_count.total) { throw 'Errors during update' }
+#if ($global:info.Error) { throw 'Errors during update' }


### PR DESCRIPTION
## What have I done?

This commit adds an argument completer to complete name (package ID) and forcedpackages.

Also makes some minor changes to improve understandability of the code, removes some excess whitespace, and fixes up a commented out suggestion that may not work.

## Why have I done this?

When testing and validating the updates in the scripts, I have found myself to want an autocompleter for the package IDs.

## Related Issue(s)

Closes #54 (possibly)

If we're happy with this, I can update [this PR](https://github.com/chocolatey-community/chocolatey-packages/pull/2498) for the Chocolatey Community Chocolatey Packages repository.